### PR TITLE
Don't preload audio files (configurable) + merging old commits

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    attachinary (1.3.1)
+    attachinary (1.3.2)
       cloudinary (~> 1.1.0)
       rails (>= 3.2)
 

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -31,10 +31,6 @@
 
   $.fn.attachinary = (options) ->
     settings = $.extend {}, $.attachinary.config, options
-    console.log ('testing')
-    console.log(settings)
-    console.log(options)
-    console.log($.attachinary.config)
 
     this.each ->
       $this = $(this)

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -6,6 +6,7 @@
       disableWith: 'Uploading...'
       indicateProgress: true
       invalidFormatMessage: 'Invalid file format'
+      preload: 'none'
       template: """
         <ul>
           <% for(var i=0; i<files.length; i++){ %>
@@ -13,7 +14,7 @@
               <% if(files[i].resource_type == "raw") { %>
                 <div class="raw-file"></div>
               <% } else if (["mp3", "m4a"].indexOf(files[i].format) > -1) { %>
-                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>" controls preload="none"/>
+                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>" controls preload="<%=  %>"/>
               <% } else { %>
                 <img
                   src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "format": 'jpg', "crop": 'fill', "width": 75, "height": 75 }) %>"
@@ -30,6 +31,10 @@
 
   $.fn.attachinary = (options) ->
     settings = $.extend {}, $.attachinary.config, options
+    console.log ('testing')
+    console.log(settings)
+    console.log(options)
+    console.log($.attachinary.config)
 
     this.each ->
       $this = $(this)

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -12,8 +12,8 @@
             <li>
               <% if(files[i].resource_type == "raw") { %>
                 <div class="raw-file"></div>
-              <% } else if (files[i].format == "mp3") { %>
-                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": 'mp3'}) %>" controls />
+              <% } else if (["mp3", "m4a"].indexOf(files[i].format) > -1) { %>
+                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>" controls />
               <% } else { %>
                 <img
                   src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "format": 'jpg', "crop": 'fill', "width": 75, "height": 75 }) %>"

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -14,7 +14,7 @@
               <% if(files[i].resource_type == "raw") { %>
                 <div class="raw-file"></div>
               <% } else if (["mp3", "m4a"].indexOf(files[i].format) > -1) { %>
-                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>" controls preload="none"/>
+                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>" controls preload="<%= options.preload %>"/>
               <% } else { %>
                 <img
                   src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "format": 'jpg', "crop": 'fill', "width": 75, "height": 75 }) %>"
@@ -25,8 +25,8 @@
           <% } %>
         </ul>
       """
-      render: (files) ->
-        $.attachinary.Templating.template(@template, files: files)
+      render: (files, options) ->
+        $.attachinary.Templating.template(@template, files: files, options: options)
 
 
   $.fn.attachinary = (options) ->
@@ -167,7 +167,7 @@
       if @files.length > 0
         @$filesContainer.append @makeHiddenField(JSON.stringify(@files))
 
-        @$filesContainer.append @config.render(@files)
+        @$filesContainer.append @config.render(@files, @options)
         @$filesContainer.find('[data-remove]').on 'click', (event) =>
           event.preventDefault()
           @removeFile $(event.target).data('remove')

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -13,7 +13,8 @@
               <% if(files[i].resource_type == "raw") { %>
                 <div class="raw-file"></div>
               <% } else if (["mp3", "m4a"].indexOf(files[i].format) > -1) { %>
-                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>" controls preload="<%= options.preload %>"/>
+                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>"
+                  controls preload="<%= options.preload %>" class="<%= options.class %>"/>
               <% } else { %>
                 <img
                   src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "format": 'jpg', "crop": 'fill', "width": 75, "height": 75 }) %>"

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -13,7 +13,7 @@
               <% if(files[i].resource_type == "raw") { %>
                 <div class="raw-file"></div>
               <% } else if (["mp3", "m4a"].indexOf(files[i].format) > -1) { %>
-                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>" controls preload="metadata"/>
+                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>" controls preload="none"/>
               <% } else { %>
                 <img
                   src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "format": 'jpg', "crop": 'fill', "width": 75, "height": 75 }) %>"

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -14,7 +14,7 @@
               <% if(files[i].resource_type == "raw") { %>
                 <div class="raw-file"></div>
               <% } else if (["mp3", "m4a"].indexOf(files[i].format) > -1) { %>
-                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>" controls preload="<%=  %>"/>
+                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>" controls preload="none"/>
               <% } else { %>
                 <img
                   src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "format": 'jpg', "crop": 'fill', "width": 75, "height": 75 }) %>"

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -13,7 +13,7 @@
               <% if(files[i].resource_type == "raw") { %>
                 <div class="raw-file"></div>
               <% } else if (["mp3", "m4a"].indexOf(files[i].format) > -1) { %>
-                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>" controls />
+                <audio src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "resource_type": 'video', "format": files[i].format }) %>" controls preload="metadata"/>
               <% } else { %>
                 <img
                   src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "format": 'jpg', "crop": 'fill', "width": 75, "height": 75 }) %>"

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -6,7 +6,6 @@
       disableWith: 'Uploading...'
       indicateProgress: true
       invalidFormatMessage: 'Invalid file format'
-      preload: 'none'
       template: """
         <ul>
           <% for(var i=0; i<files.length; i++){ %>

--- a/lib/attachinary/version.rb
+++ b/lib/attachinary/version.rb
@@ -1,3 +1,3 @@
 module Attachinary
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end

--- a/lib/attachinary/view_helpers.rb
+++ b/lib/attachinary/view_helpers.rb
@@ -54,6 +54,7 @@ module Attachinary
       options[:html][:data] ||= {}
       options[:html][:data][:attachinary] = options[:attachinary] || {}
       options[:html][:data][:attachinary][:files] = [model.send(relation)].compact.flatten
+      options[:html][:data][:attachinary][:preload] = options[:preload] || 'none'
 
       options[:html][:data][:form_data] = cloudinary_params.reject{ |k, v| v.blank? }
       options[:html][:data][:url] = cloudinary_upload_url

--- a/lib/attachinary/view_helpers.rb
+++ b/lib/attachinary/view_helpers.rb
@@ -39,8 +39,12 @@ module Attachinary
 
       if !options[:html][:accept] && accepted_types = options[:attachinary][:accept]
         accept = accepted_types.map do |type|
-          MIME::Types.type_for(type.to_s)[0]
-        end.compact
+          if ["m4a", "mp3"].include?(type.to_s)
+            MIME::Type.new("audio/*")
+          else
+            MIME::Types.type_for(type.to_s)[0]
+          end
+        end.compact.flatten
         options[:html][:accept] = accept.join(',') unless accept.empty?
       end
 

--- a/lib/attachinary/view_helpers.rb
+++ b/lib/attachinary/view_helpers.rb
@@ -55,6 +55,7 @@ module Attachinary
       options[:html][:data][:attachinary] = options[:attachinary] || {}
       options[:html][:data][:attachinary][:files] = [model.send(relation)].compact.flatten
       options[:html][:data][:attachinary][:preload] = options[:preload] || 'none'
+      options[:html][:data][:attachinary][:class] = options[:class] || ''
 
       options[:html][:data][:form_data] = cloudinary_params.reject{ |k, v| v.blank? }
       options[:html][:data][:url] = cloudinary_upload_url

--- a/lib/attachinary/view_helpers.rb
+++ b/lib/attachinary/view_helpers.rb
@@ -1,4 +1,5 @@
 require 'mime/types'
+require 'set'
 
 module Attachinary
   module ViewHelpers
@@ -40,11 +41,11 @@ module Attachinary
       if !options[:html][:accept] && accepted_types = options[:attachinary][:accept]
         accept = accepted_types.map do |type|
           if ["m4a", "mp3"].include?(type.to_s)
-            MIME::Type.new("audio/*")
+            [MIME::Type.new("audio/*"), ".#{type}"]
           else
-            MIME::Types.type_for(type.to_s)[0]
+            [MIME::Types.type_for(type.to_s)[0], ".#{type}"]
           end
-        end.compact.flatten
+        end.compact.flatten.map(&:to_s).to_set.to_a
         options[:html][:accept] = accept.join(',') unless accept.empty?
       end
 


### PR DESCRIPTION
**Description**

Now we can specify the `preload` attribute for `audio` elements (the default will be '`none`'). Also, we referencing a commit that is not in master in songfinch production, some of the changes from this PR come from those old commits.