### PR TITLE
ENG-784 Mark cloudinary resources for deletion

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    attachinary (1.3.2)
+    attachinary (1.3.3)
       cloudinary (~> 1.1.0)
       rails (>= 3.2)
 

--- a/lib/attachinary/orm/active_record/extension.rb
+++ b/lib/attachinary/orm/active_record/extension.rb
@@ -36,7 +36,7 @@ module Attachinary
       define_method "#{options[:scope]}=" do |input, upload_options = {}|
         input = Attachinary::Utils.process_input(input, upload_options, options[:scope])
         if input.nil?
-          send("#{relation}").clear
+          send("#{relation}").destroy_all
         else
           files = [input].flatten
           send("#{relation}=", files)

--- a/lib/attachinary/orm/file_mixin.rb
+++ b/lib/attachinary/orm/file_mixin.rb
@@ -5,7 +5,7 @@ module Attachinary
       if Rails::VERSION::MAJOR == 3
         base.attr_accessible :public_id, :version, :width, :height, :format, :resource_type
       end
-      base.after_destroy :destroy_file
+      base.after_commit :destroy_file, on: :destroy
       base.after_create  :remove_temporary_tag
     end
 

--- a/lib/attachinary/version.rb
+++ b/lib/attachinary/version.rb
@@ -1,3 +1,3 @@
 module Attachinary
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end


### PR DESCRIPTION
### Links

Jira: https://songfinch.atlassian.net/browse/ENG-784
Related PR: https://github.com/songfinch/rails-app/pull/2248

### Description

Based on [this issue](https://github.com/assembler/attachinary/issues/138) and [this PR](https://github.com/assembler/attachinary/pull/139).

- Attachinary uses [relationship.clear](https://apidock.com/rails/ActiveRecord/Associations/CollectionProxy/clear) which doesn't trigger `after_destroy`. We need to listen to destroy events so we can remove resources from Cloudinary. So if we just change `clear` for `destroy_all` that should fix it.
- Instead of calling `destroy_file` on `after_destroy`, it would be safer to do it in an `after_commit` callback. NOTE: this will only destroy non-video assets, for video assets you need to specify the resource type. But we will take care of that in our main app.